### PR TITLE
Upgrade phpMyAdmin to 5.0.4

### DIFF
--- a/phpmyadmin/Dockerfile
+++ b/phpmyadmin/Dockerfile
@@ -25,7 +25,7 @@ RUN \
     \
     && mkdir /var/www/phpmyadmin \
     && curl -L -s \
-        "https://files.phpmyadmin.net/phpMyAdmin/5.0.2/phpMyAdmin-5.0.2-all-languages.tar.gz" \
+        "https://files.phpmyadmin.net/phpMyAdmin/5.0.4/phpMyAdmin-5.0.4-all-languages.tar.gz" \
         | tar zxvf - --strip 1 -C /var/www/phpmyadmin \
     \
     && sed -i "s@define('CONFIG_DIR'.*@define('CONFIG_DIR', '/etc/phpmyadmin/');@" \


### PR DESCRIPTION
# Proposed Changes

Upgrades phpMyAdmin to the latest and greatest 5.0.4

https://www.phpmyadmin.net/news/2020/10/15/phpmyadmin-497-and-504-are-released/