### PR TITLE
Add php7-xml

### DIFF
--- a/phpmyadmin/Dockerfile
+++ b/phpmyadmin/Dockerfile
@@ -20,6 +20,7 @@ RUN \
         php7-mysqli=7.4.15-r0 \
         php7-opcache=7.4.15-r0 \
         php7-session=7.4.15-r0 \
+        php7-xml=7.4.15-r0 \
         php7-zip=7.4.15-r0 \
         php7=7.4.15-r0 \
     \


### PR DESCRIPTION
# Proposed Changes

PHP's XML extension is now required for phpMyAdmin to function.
