### PR TITLE
🔨 Add Upload limit option

### DIFF
--- a/phpmyadmin/DOCS.md
+++ b/phpmyadmin/DOCS.md
@@ -34,6 +34,7 @@ log_level: info
 
 By default the size limit for uploads (for operations such as imports) is set to
 64MB.  This can be increased with this option, for example `100` would be 100MB.
+
 ### Option: `log_level`
 
 The `log_level` option controls the level of log output by the addon and can

--- a/phpmyadmin/DOCS.md
+++ b/phpmyadmin/DOCS.md
@@ -32,8 +32,8 @@ log_level: info
 
 ### Option: `upload_limit`
 
-By default the size limit for uploads (for operations such as imports) is set to
-64MB.  This can be increased with this option, for example `100` would be 100MB.
+By default, the size limit for uploads (for operations such as imports) is set to
+64MB. This can be increased with this option, for example, `100` would be 100MB.
 
 ### Option: `log_level`
 

--- a/phpmyadmin/DOCS.md
+++ b/phpmyadmin/DOCS.md
@@ -30,6 +30,10 @@ log_level: info
 
 **Note**: _This is just an example, don't copy and paste it! Create your own!_
 
+### Option: `upload_limit`
+
+By default the size limit for uploads (for operations such as imports) is set to
+64MB.  This can be increased with this option, for example `100` would be 100MB.
 ### Option: `log_level`
 
 The `log_level` option controls the level of log output by the addon and can

--- a/phpmyadmin/config.yaml
+++ b/phpmyadmin/config.yaml
@@ -19,3 +19,4 @@ services:
 hassio_api: true
 schema:
   log_level: list(trace|debug|info|notice|warning|error|fatal)?
+  upload_limit: int?

--- a/phpmyadmin/rootfs/etc/cont-init.d/nginx.sh
+++ b/phpmyadmin/rootfs/etc/cont-init.d/nginx.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/with-contenv bashio
+# ==============================================================================
+# Home Assistant Community Add-on: phpMyAdmin
+# Configures nginx
+# ==============================================================================
+declare upload_limit
+
+upload_limit="64M"
+
+if bashio::config.has_value 'upload_limit'; then
+    upload_limit=$(bashio::config "upload_limit")M
+fi
+
+sed -i "s/%%upload_limit%%/${upload_limit}/g" \
+    /etc/nginx/includes/server_params.conf

--- a/phpmyadmin/rootfs/etc/nginx/includes/server_params.conf
+++ b/phpmyadmin/rootfs/etc/nginx/includes/server_params.conf
@@ -6,7 +6,7 @@ add_header X-Content-Type-Options nosniff;
 add_header X-XSS-Protection "1; mode=block";
 add_header X-Robots-Tag none;
 
-client_max_body_size 64M;
+client_max_body_size %%upload_limit%%;
 
 location / {
     try_files $uri $uri/ /index.php?$query_string;

--- a/phpmyadmin/rootfs/etc/php8/conf.d/99-phpmyadmin.ini
+++ b/phpmyadmin/rootfs/etc/php8/conf.d/99-phpmyadmin.ini
@@ -11,7 +11,5 @@ opcache.revalidate_freq=2
 opcache.validate_timestamps=0
 session.cookie_httponly=1
 session.use_strict_mode=1
-php_admin_value[post_max_size] = 64M
-php_admin_value[upload_max_filesize] = 64M
-
-
+post_max_size = ${UPLOAD_LIMIT}
+upload_max_filesize = ${UPLOAD_LIMIT}

--- a/phpmyadmin/rootfs/etc/services.d/php-fpm/run
+++ b/phpmyadmin/rootfs/etc/services.d/php-fpm/run
@@ -9,10 +9,15 @@ export SERVICE_HOST
 export SERVICE_PASSWORD
 export SERVICE_PORT
 export SERVICE_USERNAME
+export UPLOAD_LIMIT=64M
 
 SERVICE_HOST=$(bashio::services "mysql" "host")
 SERVICE_PASSWORD=$(bashio::services "mysql" "password")
 SERVICE_PORT=$(bashio::services "mysql" "port")
 SERVICE_USERNAME=$(bashio::services "mysql" "username")
+
+if bashio::config.has_value 'upload_limit' ; then
+    UPLOAD_LIMIT=$(bashio::config 'upload_limit')M
+fi
 
 exec php-fpm8 --nodaemonize


### PR DESCRIPTION
# Proposed Changes

Adds config option for upload limit (defaults to 64MB)

Needed to update PHP for CI to run, so updated image as well (Can split this out if needed).

I know the config needs shifting to Tempio, however thought there were too many changes as is.

Validated working:

![image](https://user-images.githubusercontent.com/24625998/148665858-5807ff5a-4c1d-4701-bc7d-de541c362271.png)


![image](https://user-images.githubusercontent.com/24625998/148665875-8f774d40-0b4e-4576-ac4f-3dcf0879458d.png)


For some reason I can't see the edit options in the UI for the config option, not sure if this is intended for an optional int?

## Related Issues

closes #116 
