### PR TITLE
Extend max query execution time to 1 hour

### DIFF
--- a/phpmyadmin/rootfs/etc/nginx/servers/ingress.conf
+++ b/phpmyadmin/rootfs/etc/nginx/servers/ingress.conf
@@ -8,7 +8,7 @@ server {
 
     location ~ .php$ {
         fastcgi_pass 127.0.0.1:9001;
-        fastcgi_read_timeout 900;
+        fastcgi_read_timeout 3610;
         fastcgi_split_path_info ^(.+\.php)(/.+)$;
         fastcgi_index index.php;
         fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;

--- a/phpmyadmin/rootfs/etc/php81/conf.d/99-phpmyadmin.ini
+++ b/phpmyadmin/rootfs/etc/php81/conf.d/99-phpmyadmin.ini
@@ -1,6 +1,6 @@
 [general]
 allow_url_fopen = Off
-max_execution_time = 900
+max_execution_time = 3610
 memory_limit=256M
 opcache.enable=1
 opcache.fast_shutdown=1

--- a/phpmyadmin/rootfs/etc/phpmyadmin/config.inc.php
+++ b/phpmyadmin/rootfs/etc/phpmyadmin/config.inc.php
@@ -4,6 +4,7 @@ require('/data/config.secret.inc.php');
 
 $cfg['AllowThirdPartyFraming'] = true;
 $cfg['CheckConfigurationPermissions'] = false;
+$cfg['ExecTimeLimit'] = 3600;
 $cfg['SaveDir'] = '';
 $cfg['TempDir'] = sys_get_temp_dir();
 $cfg['UploadDir'] = '';


### PR DESCRIPTION
# Proposed Changes

Sets the max query execution time to 1 hour.
(+10 seconds for related timeouts higher up).

## Related Issues

#142
