### PR TITLE
Fix MySQL commands

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "todo-tree.tree.scanMode": "workspace"
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,3 @@
 {
-    "todo-tree.tree.scanMode": "workspace"
+  "todo-tree.tree.scanMode": "workspace"
 }

--- a/phpmyadmin/rootfs/etc/s6-overlay/s6-rc.d/init-phpmyadmin/run
+++ b/phpmyadmin/rootfs/etc/s6-overlay/s6-rc.d/init-phpmyadmin/run
@@ -24,17 +24,19 @@ port=$(bashio::services "mysql" "port")
 username=$(bashio::services "mysql" "username")
 
 database=$(\
-    mysql \
+    mariadb \
         -u "${username}" -p"${password}" \
         -h "${host}" -P "${port}" \
         --skip-column-names \
+        --skip-ssl \
         -e "SHOW DATABASES LIKE 'phpmyadmin';"
 )
 
 if ! bashio::var.has_value "${database}"; then
     bashio::log.info "Creating database for phpMyAdmin"
-    mysql \
+    mariadb \
         -u "${username}" -p"${password}" \
         -h "${host}" -P "${port}" \
+        --skip-ssl \
             < /var/www/phpmyadmin/sql/create_tables.sql
 fi


### PR DESCRIPTION
# Proposed Changes

- `mysql` is being replaced by `mariadb` (alias is now deprecated).
- The MariaDB CLI now uses SSL by default, but HA doesn't.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced Todo Tree extension to scan the entire workspace for TODO comments.
  
- **Bug Fixes**
	- Updated database commands in phpMyAdmin configuration to use MariaDB instead of MySQL, improving compatibility with the current database management system.
  
- **Chores**
	- Added `--skip-ssl` option to database commands for improved connection settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->